### PR TITLE
Disable DTLSUDP & TLSTCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ on top of [Net-SNMP](http://www.net-snmp.org) C library.
 
 The key differences from the upstream library are:
 
-- Includes Net-SNMP source code so that we can build binary wheel distributions in addition to source distributions - this provides a self contained distribution
+- Includes Net-SNMP source code which is used to build shared objects during installation leading to self contained distributions
 - Locks down options for the Net-SNMP library: for example, SNMPv1 is disabled and TLS is enabled
+- No MIBs are include in the distribution - this is by design since using symbolic OIDs is slow
 - A Python based implementation of bulk_walk
 - Support for tunneled SNMP connections
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ on top of [Net-SNMP](http://www.net-snmp.org) C library.
 The key differences from the upstream library are:
 
 - Includes Net-SNMP source code which is used to build shared objects during installation leading to self contained distributions
-- Locks down options for the Net-SNMP library: for example, SNMPv1 is disabled and TLS is enabled
+- Locks down options for the Net-SNMP library: for example, SNMPv1 is and applications are disabled
 - No MIBs are include in the distribution - this is by design since using symbolic OIDs is slow
 - A Python based implementation of bulk_walk
-- Support for tunneled SNMP connections
+- Fix support for tunneled SNMP connections
 
 ## Install
 

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ class BuildEasySNMPExt(build_ext):
                 configureargs = "--with-defaults --with-default-snmp-version=2 --with-sys-contact=root@localhost " \
                                 "--with-logfile=/var/log/snmpd.log " \
                                 "--with-persistent-directory=/var/net-snmp --with-sys-location=unknown " \
-                                "--with-transports=TLSTCP --without-rpm"
+                                "--without-rpm"
 
                 featureflags = '--enable-reentrant --disable-debugging --disable-embedded-perl ' \
                                '--without-perl-modules --enable-static=no --disable-snmpv1 --disable-applications ' \
@@ -103,7 +103,7 @@ class BuildEasySNMPExt(build_ext):
                 configurecmd = "./configure --build={0}-unknown-linux-gnu --host={0}-unknown-linux-gnu " \
                                "{1} {2}".format(MACHINE, configureargs, featureflags).split(' ')
 
-                configurecmd += ['--with-security-modules=usm tsm']
+                configurecmd += ['--with-security-modules=usm tsm', '--with-out-transports=DTLSUDP TLSTCP']
                 makecmd = ['make']
 
                 print(">>>>>>>>>>> Configuring with {0}".format(' '.join(configurecmd)))
@@ -111,7 +111,7 @@ class BuildEasySNMPExt(build_ext):
                    check_call(configurecmd, cwd=NETSNMP_SRC_PATH, stdout=log)
 
                 print(">>>>>>>>>>> Building net-snmp library in {}".format(NETSNMP_SRC_PATH))
-                with open("/tmp/yahoo-panoptes-snmp-net-snmp-make.log".format(BUILD_START_TIME), 'w+') as log:
+                with open("/tmp/yahoo-panoptes-snmp-net-snmp-make-{0}.log".format(BUILD_START_TIME), 'w+') as log:
                    check_call(makecmd, cwd=NETSNMP_SRC_PATH, stdout=log)
 
                 print(">>>>>>>>>>> Copying shared objects")


### PR DESCRIPTION
These require linking against OpenSSL - and on Ubuntu 16.04 onwards, OpenSSL has been upgraded to 1.1.0 which Net-SNMP 5.7.3 does not play nice with.

Will review and patch in the future to re-enable.

Also fixed a print format string and updated documentation.